### PR TITLE
Change key in utils/contracts.js from development to unknown

### DIFF
--- a/client/utils/contracts.js
+++ b/client/utils/contracts.js
@@ -7,7 +7,7 @@ export default {
     solidity_storage: '0x3ACf6173Fd4f2958d37A487A48B3349DcA51F6B3',
     vyper_storage: '0x4e260f130c4f774d7B05cb0d3f7F13B272eE4998',
   },
-  development: {
+  unknown: {
     solidity_storage: '0x674E5F7Eb580534f188Be5403cd90A0a9934C8e6',
     vyper_storage: '0x8f5Cc00024B2481ab8f3a53AC4a20D6351b7E67f',
   },


### PR DESCRIPTION
From this [`console.log(network)`](https://github.com/rafael-abuawad/brownie-next-mix/blob/24b55956b01df27bcb3cb259afa113f6c21f6193/client/pages/_app.js#L26) turns out that instead of `development` it has to be `unknown` now as the key in _utils/contracts.js_.